### PR TITLE
d/t/basic-smoke: remove shell's -u option

### DIFF
--- a/debian/tests/basic-smoke
+++ b/debian/tests/basic-smoke
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eeuo pipefail
+set -Eeo pipefail
 set -x
 
 # stop service


### PR DESCRIPTION
The only case where it is relevant is when the proxy environment variable is expanded. This variable is expected to be empty in most local test run use cases. The tests should proceed in such cases.