### PR TITLE
Build with golang 1.23

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 containerd-app (2.0.5-0ubuntu1~24.10.1) oracular; urgency=medium
 
   * Backport from questing to oracular (LP: #2110139)
-  * d/control: build with golang 1.24
-  * d/rules: add golang 1.24 to PATH
+  * d/control: build with golang 1.23
+  * d/rules: add golang 1.23 to PATH
 
  -- Athos Ribeiro <athos.ribeiro@canonical.com>  Wed, 07 May 2025 11:51:13 -0300
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 12),
                dh-golang,
                go-md2man,
-               golang-1.24-go,
+               golang-1.23-go,
                libbtrfs-dev | btrfs-progs (<< 4.16.1~),
                libseccomp-dev,
                pkgconf,

--- a/debian/rules
+++ b/debian/rules
@@ -14,8 +14,8 @@ export GOCACHE := $(CURDIR)/.gocache
 # https://blog.golang.org/go116-module-changes (TODO figure out a new solution for Go 1.17+)
 export GO111MODULE := auto
 
-# Build with Golang 1.24
-export PATH := /usr/lib/go-1.24/bin:$(PATH)
+# Build with Golang 1.23
+export PATH := /usr/lib/go-1.23/bin:$(PATH)
 
 execute_before_dh_gencontrol:
 	# use "dh_golang" to generate "misc:Built-Using" (via "go list")


### PR DESCRIPTION
Oracular does not have go 1.24. Let's build this with golang 1.23 instead.